### PR TITLE
Restore root span context after span

### DIFF
--- a/api/godog/tracecontext/context.go
+++ b/api/godog/tracecontext/context.go
@@ -81,14 +81,12 @@ func (tc *traceCtx) beforeStep(s *godog.Step) {
 		return
 	}
 
-	tc.stepSpan = dd_tracer.StartSpan(stepOperationName,
+	tc.rootSpan, tc.Context = dd_tracer.StartSpanFromContext(tc.rootContext, stepOperationName,
 		dd_tracer.SpanType(spanType),
-		dd_tracer.ChildOf(tc.rootSpan.Context()),
 	)
 
 	tc.stepSpan.SetTag(dd_ext.ResourceName, s.Text)
 	tc.stepSpan.SetTag(tagStepID, s.Id)
-	tc.Context = dd_tracer.ContextWithSpan(tc.Context, tc.stepSpan)
 }
 
 func (tc *traceCtx) afterStep(s *godog.Step, err error) {

--- a/api/godog/tracecontext/context.go
+++ b/api/godog/tracecontext/context.go
@@ -30,6 +30,7 @@ type GodogScenarioContext interface {
 
 type traceCtx struct {
 	context.Context
+	rootContext context.Context
 
 	rootSpan dd_tracer.Span
 	stepSpan dd_tracer.Span
@@ -59,6 +60,7 @@ func (tc *traceCtx) beforeScenario(s *godog.Scenario) {
 	tc.rootSpan, tc.Context = dd_tracer.StartSpanFromContext(tc.Context, testOperationName,
 		dd_tracer.SpanType(spanType),
 	)
+	tc.rootContext = tc.Context
 
 	tc.rootSpan.SetTag(dd_ext.ResourceName, s.Name)
 	tc.rootSpan.SetTag(tagTestID, s.Id)
@@ -95,6 +97,7 @@ func (tc *traceCtx) afterStep(s *godog.Step, err error) {
 	}
 
 	tc.stepSpan.Finish(dd_tracer.WithError(err))
+	tc.Context = tc.rootContext
 }
 
 func (tc *traceCtx) SetTag(key string, value interface{}) {

--- a/api/godog/tracecontext/context.go
+++ b/api/godog/tracecontext/context.go
@@ -81,7 +81,7 @@ func (tc *traceCtx) beforeStep(s *godog.Step) {
 		return
 	}
 
-	tc.rootSpan, tc.Context = dd_tracer.StartSpanFromContext(tc.rootContext, stepOperationName,
+	tc.stepSpan, tc.Context = dd_tracer.StartSpanFromContext(tc.rootContext, stepOperationName,
 		dd_tracer.SpanType(spanType),
 	)
 


### PR DESCRIPTION
beforeStep replaces the traceCtx.Context when it has created the child
span. This will link spans created with tracer.SpanFromContext on
traceCtx, after a step has been executed, to the step span, instead of
the root span.

So a span created after all steps are executed (e.g. in teardown code)
will be linked to the last span of the test case.