### PR TITLE
Fix expected status code for delete user access

### DIFF
--- a/users/user_access.go
+++ b/users/user_access.go
@@ -77,7 +77,7 @@ func RemoveUserAccessWithContext(ctx context.Context, identityToken, stage, user
 		return errors.Wrap(err, "failed to execute request")
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusAccepted {
 		return errors.Errorf("wrong response status: %q", resp.Status)
 	}
 


### PR DESCRIPTION
The delete user access endpoint returns 202 Accepted on success, not 200 OK.

https://access-api.sandbox.users.enlight.skf.com/docs/swagger/index.html#/Access/delete_users__userId__nodes__nodeId_